### PR TITLE
feat(paginate): recognize further pages by x-next-page header

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strconv"
 	"net/http"
 )
 
@@ -14,27 +15,28 @@ type Job struct {
 func main () {
 	var project_id int
 	var per_page int
-	var pages int
+	var start_page int
+	var current_page int
 	var token string
 	var server string
 
 	flag.IntVar(&project_id, "project_id", 0, "Project ID")
 	flag.IntVar(&per_page, "per_page", 100, "Number of jobs per page")
-	flag.IntVar(&pages, "pages", 1, "Number of pages")
+	flag.IntVar(&start_page, "start-page", 1, "Start pages")
 	flag.StringVar(&token, "token", "", "Private token")
 	flag.StringVar(&server, "server", "", "Gitlab server")
 	flag.Parse()
 
-	fmt.Printf("Fetching %d pages from %v\n", pages, server)
+	current_page = start_page
 
-	for i := 1; i <= pages; i++ {
-		url := fmt.Sprintf("%v/api/v4/projects/%v/jobs?per_page=%d&page=%d&artifact_expired=false", server, project_id, per_page, i)
+	for true {
+		url := fmt.Sprintf("%v/api/v4/projects/%v/jobs?pagination=keyset&page=%d&per_page=%d&order_by=id&sort=asc&artifact_expired=false", server, project_id, current_page, per_page)
+
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		println("page number:", i)
 		req.Header.Set("PRIVATE-TOKEN", token)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -50,8 +52,10 @@ func main () {
 			return
 		}
 
+		fmt.Printf("page number: %s of %s\n", resp.Header.Get("x-page"), resp.Header.Get("x-total-pages"))
+
 		for _, job := range jobs {
-			fmt.Println("job to process:", job.ID)
+			fmt.Println("deleting artifacts of job:", job.ID)
 			url := fmt.Sprintf("%v/api/v4/projects/%v/jobs/%d/artifacts", server, project_id, job.ID)
 			req, err := http.NewRequest("DELETE", url, nil)
 			if err != nil {
@@ -65,7 +69,14 @@ func main () {
 				return
 			}
 			defer resp.Body.Close()
-			fmt.Println("job artifacts deleted:", job.ID)
 		}
+
+		next := resp.Header.Get("x-next-page")
+		next_page, err := strconv.Atoi(next)
+		if err != nil || next == "" || current_page == next_page {
+			println("no more pages. exiting")
+			return
+		}
+		current_page = next_page
 	}
 }


### PR DESCRIPTION
My first steps in Go - feel free to suggest any kind of improvements.

This PR would change the pagination-handling by giving it a start-page and from there on it brachiates from page to page on its own.

Then you as user don't need to guess in advance how many pages you have to handle.